### PR TITLE
Adding a json feed

### DIFF
--- a/site/feed.njk
+++ b/site/feed.njk
@@ -1,0 +1,22 @@
+---
+permalink: feed.json
+---
+{
+  "source" : "https://conferences.css-tricks.com",
+  "conferences" : [
+    {% for conf in collections.conferences -%}
+    {
+      "title" : "{{ conf.data.title }}",
+      "date" : "{{ conf.data.date }}",
+      {%- if conf.data.endDate %}
+      "endDate" : "{{ conf.data.endDate }}"
+      {%- endif %}
+      "url" : "{{ conf.data.url }}",
+      "location" : "{{ conf.data.location }}",
+      "byline" : "{{ conf.data.byline }}",
+      {%- if conf.data.cocUrl %}
+      "cocUrl" : "{{ conf.data.cocUrl }}"
+      {%- endif %}
+    }{% if not loop.last %},{% else %}{% endif %}
+    {% endfor -%}
+]}


### PR DESCRIPTION
Exposing this yummy data as a json feed would be amazing. It would make this resource even more valuable for the community to maintain as the canonical repository of this information that others could consume programatically as well as via the site.

## Testing:

Once built, this should expose this url: `/feed.json`

