### PR TITLE
Fix end date for Vue.Js Amsterdam

### DIFF
--- a/site/conferences/2019-vuejs-amsterdam.md
+++ b/site/conferences/2019-vuejs-amsterdam.md
@@ -3,7 +3,7 @@ title: "Vue.Js Amsterdam"
 url: https://www.vuejs.amsterdam/
 cocUrl: http://confcodeofconduct.com/
 date: 2019-02-14
-endDate: 2019-12-15
+endDate: 2019-02-15
 location: Amsterdam, Netherlands
 byline: Share knowledge with over 2000 Vue.js enthusiasts
 ---


### PR DESCRIPTION
Noticed Vue.Js Amsterdam was originally set to run from February into December (wouldn't that be a feat!).

Come to think of it, that would be awesome. Someone get Evan on the horn!