### PR TITLE
Copy favicon and apple-touch-icon to dist folder

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -37,6 +37,8 @@ module.exports = function(config) {
   });
 
   config.addPassthroughCopy("site/script");
+  config.addPassthroughCopy("apple-touch-icon.png");
+  config.addPassthroughCopy("favicon.ico");
 
   return {
     dir: { input: "site", output: "dist", includes: "_includes" },


### PR DESCRIPTION
Looks like favicons and touch icons were not being added to the `dist` folder.