### PR TITLE
Create 2019-enterjs-darmstadt.md

### DIFF
--- a/site/conferences/2019-enterjs-darmstadt.md
+++ b/site/conferences/2019-enterjs-darmstadt.md
@@ -1,0 +1,11 @@
+---
+title: enterJS
+url: https://www.enterjs.de/
+cocUrl: https://www.enterjs.de/diversity#code-of-conduct-english
+date: 2019-06-25
+endDate: 2019-06-28
+location: Darmstadt, Germany
+byline: The conference for Enterprise JavaScript
+---
+
+EnterJS opens its doors for the sixth time in 2019 for a comprehensive view of a JavaScript-powered enterprise world. It helps developers to tap into the potential of contemporary web technologies. As in the past years, the organizers of the enterJS - heise Developer, the magazine iX, and the dpunkt.verlag - attach great importance to a respectful coexistence and a balanced amount of diversity.


### PR DESCRIPTION
This PR will add enterJS Germany to the list of conferences.