### PR TITLE
Source order change, adding abbr

### DIFF
--- a/site/_includes/conference.njk
+++ b/site/_includes/conference.njk
@@ -1,3 +1,15 @@
+
+
+
+<div>
+<h3 class="conf-title">
+  <a href="{{ conf.data.url }}">
+    {{ conf.data.title }}
+  </a>
+</h3>
+</div>
+
+<div>
 <time class="conf-dates" aria-label="Conference starts on {{ conf.data.date | readableDate }}">
   <span class="icon" aria-hidden="true">📆</span>
   <span>{{ conf.data.date | readableDate }}</span>
@@ -8,17 +20,14 @@
   >
   {% endif %}
 </time>
+</div>
 
-<h3 class="conf-title">
-  <a href="{{ conf.data.url }}">
-    {{ conf.data.title }}
-  </a>
-</h3>
-
-<address class="conf-location"  aria-label="Conference location">
+<div>
+<address class="conf-location" aria-label="Conference location">
   <span class="icon" aria-hidden="true">📍</span>
   {{ conf.data.location }}
 </address>
+</div>
 
 <div class="conf-about">
   {{ conf.templateContent | safe }}

--- a/site/_includes/css/grid.css
+++ b/site/_includes/css/grid.css
@@ -88,6 +88,30 @@ body.grid .conf-link:focus {
   background: var(--dark);
 }
 
+body.grid .conf {
+  display: flex;
+  flex-direction: column;
+}
+
+body.grid .conf div:nth-child(1) {
+  order: 2;
+}
+body.grid .conf div:nth-child(2) {
+  order: 1;
+}
+body.grid .conf div:nth-child(3) {
+  order: 3;
+}
+body.grid .conf div:nth-child(4) {
+  order: 4;
+}
+
+abbr[title] {
+  border-bottom: none !important;
+  cursor: inherit !important;
+  text-decoration: none !important;
+}
+
 @media (max-width: 700px) {
   body.grid .conference-list {
     display: block;

--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -29,6 +29,7 @@
     <link rel="alternate" href="/feed.xml" title="Upcoming Conferences - CSS-Tricks" type="application/atom+xml">
   </head>
   <body class="grid">
+  
     {{ content | safe }}
 
     {% include "icons.njk" %}

--- a/site/index.njk
+++ b/site/index.njk
@@ -24,10 +24,10 @@ layout: layouts/base.njk
 
   <ul class="contribute-links">
     <li>
-      <a class="contribute-link" href="/feed.xml">RSS XML</a>
+      <a class="contribute-link" href="/feed.xml" aria-label="RSS feed"><abbr title="Really Simple Syndication">RSS</abbr> <abbr title="Extensible Markup Language">XML</abbr></a>
     </li>
     <li>
-      <a class="contribute-link" href="/feed.json">JSON</a>
+      <a class="contribute-link" href="/feed.json" aria-label="JSON feed"><abbr title="JavaScript Object Notation">JSON</abbr></a>
     </li>
     <li>
       <a
@@ -54,21 +54,23 @@ layout: layouts/base.njk
   </div>
 </header>
 
-<ul>
-  {%- for month in helper.months -%} {% if (collections.conferences |
-  doesConfExist(month)) > 0 %}
-  <li>
-    <h2 class="month-heading" aria-label="Conferences in {{ month }}">
-      {{ month }}
-    </h2>
-    <ul class="conference-list">
-      {%- for conf in collections.conferences -%} {% if conf.data.date |
-      getMonthName === month %}
-      <li class="conf">
-        {% include "conference.njk" %}
-      </li>
-      {% endif %} {%- endfor -%}
-    </ul>
-  </li>
-  {% endif %} {%- endfor -%}
-</ul>
+<div id="maincontent" role="main" aria-label="Conference listing">
+  <ul aria-label="Conference listed by months">
+    {%- for month in helper.months -%} {% if (collections.conferences |
+    doesConfExist(month)) > 0 %}
+    <li>
+      <h2 class="month-heading" aria-label="Conferences in {{ month }}">
+        {{ month }}
+      </h2>
+      <ul class="conference-list">
+        {%- for conf in collections.conferences -%} {% if conf.data.date |
+        getMonthName === month %}
+        <li class="conf">
+          {% include "conference.njk" %}
+        </li>
+        {% endif %} {%- endfor -%}
+      </ul>
+    </li>
+    {% endif %} {%- endfor -%}
+  </ul>
+</div>


### PR DESCRIPTION
Changed the source order of conference listings so that event title speaks first in VO. Used flexbox to move the date, title to their expected visual order. Added abbreviations to syndication feeds.