### PR TITLE
Dynamic Calendar Icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1933,7 +1933,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1954,12 +1955,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1974,17 +1977,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2101,7 +2107,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2113,6 +2120,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2127,6 +2135,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2134,12 +2143,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2158,6 +2169,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2238,7 +2250,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2250,6 +2263,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2335,7 +2349,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2371,6 +2386,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2390,6 +2406,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2433,12 +2450,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/site/_includes/conference.njk
+++ b/site/_includes/conference.njk
@@ -7,7 +7,7 @@
 </div>
 
 <div class="conf-dates" aria-label="Conference starts on {{ conf.data.date | readableDate }}">
-  <span class="icon" aria-hidden="true">📆</span>
+  <span class="icon-calendar" aria-hidden="true">{{ conf.data.date | htmlTime | replace(r/^.{0,8}/, "") }}</span>
   <time datetime="{{ conf.data.date | htmlTime }}" >{{ conf.data.date | readableDate }}</time>
     {% if conf.data.endDate %}
       <span class="end-date">

--- a/site/_includes/css/grid.css
+++ b/site/_includes/css/grid.css
@@ -37,11 +37,11 @@ body.grid .icon-calendar {
 	display: block;
 	height: 24px;
 	width: 24px;
-	padding-top: 6px;
+	font-size: 12px;
+	text-align: center;
 	border: 1px solid #333;
 	border-radius: 2px;
-	text-align: center;
-	font-size: 12px;
+	padding-top: 6px;
 	margin: 3px 10px 3px 2px;
 }
 body.grid .icon-calendar::before {
@@ -51,9 +51,9 @@ body.grid .icon-calendar::before {
 	left: -1px;
 	height: 4px;
 	width: 100%;
+	background: var(--rust);
 	border: 1px solid #333;
 	border-radius: 2px 2px 0px 0px;
-	background: var(--rust);
 }
 
 body.grid .conf-dates,

--- a/site/_includes/css/grid.css
+++ b/site/_includes/css/grid.css
@@ -32,6 +32,30 @@ body.grid .icon {
   margin-right: 0.5rem;
 }
 
+body.grid .icon-calendar {
+	position: relative;
+	display: block;
+	height: 24px;
+	width: 24px;
+	padding-top: 6px;
+	border: 1px solid #333;
+	border-radius: 2px;
+	text-align: center;
+	font-size: 12px;
+	margin: 3px 10px 3px 2px;
+}
+body.grid .icon-calendar::before {
+	content: '';
+	position: absolute;
+	top: -1px;
+	left: -1px;
+	height: 4px;
+	width: 100%;
+	border: 1px solid #333;
+	border-radius: 2px 2px 0px 0px;
+	background: var(--rust);
+}
+
 body.grid .conf-dates,
 body.grid .conf-location {
   display: flex;


### PR DESCRIPTION
#### Background
I was scrolling through the site and I noticed myself getting a little bit distracted by the stock calendar emoji, since the date is always set to July 17th. I thought it would be handy to have that calendar icon be quickly scannable/recognizable to the start date of the conference.

#### What I Did
I replaced the original `<span>📆</span>` with a simple element that mimics the look of the calendar emoji, but pulls in the start date of the respective conference. There's a little replace filter to remove the year and month so we're just dropping in the day. 

I know you guys wanted an email heads up before doing any design/dev work, but I figured this was a little quick win that would make it easier to quickly scan through the grid of conferences. Hope this helps! 🤞 

ps. not totally sure why the package-lock.json file got changed, I'm not as familiar with working with those files.