### PR TITLE
First crack at an archive page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,6 +11,14 @@ module.exports = function(config) {
     return futureConferences;
   });
 
+  config.addCollection('pastconferences', function(collection) {
+    let allConferences = collection.getFilteredByGlob('site/conferences/*.md');
+    let pastConferences = allConferences.filter(conf => {
+      return conf.data.date <= new Date();
+    });
+    return pastConferences;
+  });
+
   config.addFilter('getMonthName', dateObj => {
     return DateTime.fromJSDate(dateObj, {
       zone: 'utc'

--- a/site/_data/site.json
+++ b/site/_data/site.json
@@ -1,0 +1,7 @@
+{
+  "title": "Upcoming Conferences - CSS-Tricks",
+  "description": "CSS-Tricks presents a directory of upcoming web design and front-end development conferences in 2019.",
+  "url": "https://conferences.css-tricks.com/"
+}
+
+

--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -5,15 +5,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{ title }}</title>
-  <meta name="description" content="{{ description }}">
-  <meta property="og:url" content="https://conferences.css-tricks.com/">
+  <meta name="description" content="{{ site.description }}">
+  <meta property="og:url" content="{{ site.url }}">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="{{ title }}">
-  <meta property="og:description" content="{{ description }}">
+  <meta property="og:title" content="{{ site.title }}">
+  <meta property="og:description" content="{{ site.description }}">
   <meta property="og:image" content="https://css-tricks.com/wp-content/uploads/2013/06/CSS-Tricks-star.png">
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="{{ title }}">
-  <meta name="twitter:description" content="{{ description }}">
+  <meta name="twitter:title" content="{{ site.title }}">
+  <meta name="twitter:description" content="{{ site.description }}">
   <meta name="twitter:image" content="https://css-tricks.com/wp-content/uploads/2013/06/CSS-Tricks-star.png">
   <link
     href="https://fonts.googleapis.com/css?family=Rubik:700"
@@ -27,7 +27,7 @@
   <style>
     {{ css | cssmin | safe }}
   </style>
-  <link rel="alternate" href="/feed.xml" title="Upcoming Conferences - CSS-Tricks" type="application/atom+xml">
+  <link rel="alternate" href="/feed.xml" title="{{ site.title }}" type="application/atom+xml">
 </head>
 
 <body class="grid">

--- a/site/_includes/layouts/index.njk
+++ b/site/_includes/layouts/index.njk
@@ -19,8 +19,12 @@ layout: layouts/base.njk
     <span class="presents">presents</span>
   </div>
 
-  <h1>Upcoming Conferences</h1>
-  <div class="subtitle">... related to Front-End Design & Development</div>
+  <h1>{{ title }}</h1>
+  {% if lede %}
+  <p class="subtitle">{{ lede }}</p>
+  {% endif %}
+
+  {{ content | safe }}
 
   <a
     class="contribute-link"
@@ -47,6 +51,7 @@ layout: layouts/base.njk
 </header>
 
 <div id="maincontent" role="main" aria-label="Conference listing">
+
   <ul aria-label="Conference listed by months">
     {%- for month in helper.months -%} {% if (collections.conferences |
     doesConfExist(month)) > 0 %}

--- a/site/_includes/layouts/index.njk
+++ b/site/_includes/layouts/index.njk
@@ -1,6 +1,4 @@
 ---
-title: Upcoming Conferences - CSS-Tricks
-description: CSS-Tricks presents a directory of upcoming web design and front-end development conferences in 2019.
 layout: layouts/base.njk
 ---
 

--- a/site/_includes/layouts/index.njk
+++ b/site/_includes/layouts/index.njk
@@ -53,14 +53,14 @@ layout: layouts/base.njk
 <div id="maincontent" role="main" aria-label="Conference listing">
 
   <ul aria-label="Conference listed by months">
-    {%- for month in helper.months -%} {% if (collections.conferences |
+    {%- for month in helper.months -%} {% if (pagination.items |
     doesConfExist(month)) > 0 %}
     <li>
       <h2 class="month-heading" aria-label="Conferences in {{ month }}">
         {{ month }}
       </h2>
       <ul class="conference-list">
-        {%- for conf in collections.conferences -%} {% if conf.data.date |
+        {%- for conf in pagination.items -%} {% if conf.data.date |
         getMonthName === month %}
         <li class="conf">
           {% include "conference.njk" %}

--- a/site/archive/index.md
+++ b/site/archive/index.md
@@ -1,8 +1,8 @@
 ---
-title: Upcoming Conferences
+title: Past Conferences
 lede: "... related to Front-End Design & Development"
 layout: layouts/index.njk
 pagination:
-  data: collections.conferences
+  data: collections.pastconferences
   size: 999
 ---

--- a/site/index.md
+++ b/site/index.md
@@ -1,0 +1,5 @@
+---
+title: Upcoming Conferences
+lede: "... related to Front-End Design & Development"
+layout: layouts/index.njk
+---


### PR DESCRIPTION
Had to rework the way `index.njk` works a little bit, for this one: moved it into `_includes/layouts/`, moved the front-matter to `/index.md` and added /archive/index.md` to handle the title/lede on the archive page the same way. The relevant collection is passed to `index.njk` using Eleventy’s pagination data dealie, which feels a _little_ weird, but works; unless we actually want to paginate these at some point, I might still revisit that part.