### PR TITLE
Persist view setting across page reloads.

### DIFF
--- a/site/script/index.js
+++ b/site/script/index.js
@@ -2,11 +2,24 @@ const viewButtons = document.querySelectorAll('.style-switcher button');
 
 viewButtons.forEach(button => {
   button.addEventListener('click', el => {
+    var bodyClass = el.target.dataset.bodyClass;
     document.body.classList.remove('grid', 'list');
     viewButtons.forEach(button => {
       button.classList.remove('active');
     });
     el.target.classList.add('active');
     document.body.classList.add(el.target.dataset.bodyClass);
+    localStorage.setItem('view', bodyClass);
   });
 });
+
+
+(function() {
+  var savedState = localStorage.getItem('view'),
+    current;
+
+   if( savedState !== null ) {
+     current = document.querySelector('[data-body-class="' +  savedState + '"]');
+     current.click();
+   }
+}());


### PR DESCRIPTION
Ref. #97. Handy for the sake of tinkering with the two views’ styling, and maybe something we want to keep in place on production.