### PR TITLE
Temporary fix for missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "eleventy --serve",
-    "build": "eleventy"
+    "build": "eleventy",
+    "postbuild": "cd functions/send-email && npm install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This post build step can go away once https://github.com/netlify/zip-it-and-ship-it/pull/34 is merged and live in Netlify