### PR TITLE
Create 2019-FronteersConf-Amsterdam

### DIFF
--- a/site/conferences/2019-FronteersConf-Amsterdam
+++ b/site/conferences/2019-FronteersConf-Amsterdam
@@ -1,0 +1,12 @@
+---
+title: FronteersConf
+url: https://fronteers.nl/congres/2019
+cocUrl: https://fronteers.nl/congres/2019/code-of-conduct
+date: 2019-10-03
+endDate: 2019-10-04
+location: Amsterdam, the Netherlands
+byline: Back in Pathé Tuschinski for 2 days with 18 fantastic speakers.
+---
+
+Fronteers Conference is one of Europe’s premiere conferences on front-end web development, organised in Amsterdam yearly since 2008. This year our single-track community-driven conference returns to the beautiful Pathé Tuschinski theatre on Thursday and Friday, 3–4 October 2019.
+Our speakers come from all over the globe cover the full spectrum from independent developers to Github and Google team members.


### PR DESCRIPTION
Hi Chris/CSS-Tricks team! We would love to add FronteersConf to your list of conferences. I have ommitted ticket price and tried not too be too "commercial" or "pushy" in the copy text.