### PR TITLE
Add HighEdWeb Technical Academy Milwaukee 2019

### DIFF
--- a/site/conferences/2019-highedweb-milwaukee.md
+++ b/site/conferences/2019-highedweb-milwaukee.md
@@ -1,0 +1,11 @@
+---
+title: HighEdWeb Technical Academy
+url: https://technical.highedweb.org/
+cocUrl: https://www.highedweb.org/about/code-of-conduct/
+date: 2019-10-12
+endDate: 2019-10-13
+location: Milwaukee, Wisconsin
+byline: Front-end technologies, best practices, and accessibility
+---
+
+Join us for a weekend of hands-on workshops on CSS grid, accessibility, web components, and testing. Enjoy a small group setting with deep dives from speakers including Morten Rand-Hendriksen. Special focus will be on university websites, but all are welcome.


### PR DESCRIPTION
Adding a weekend academy preceding HighEdWeb 2019 that focuses on front-end web development. Talks include "How to Engineer Accessible Websites," "The Future of CSS Today," "Introduction to Web Components," and "Behavior-driven Development in JavaScript and PHP."