### PR TITLE
Add State of the Browser London

### DIFF
--- a/site/conferences/2019-stateofthebrowser-london.md
+++ b/site/conferences/2019-stateofthebrowser-london.md
@@ -1,0 +1,10 @@
+---
+title: State of the Browser 
+url: https://2019.stateofthebrowser.com/
+cocUrl: https://2019.stateofthebrowser.com/code-of-conduct/
+date: 2019-09-14
+location: London, United Kingdom
+byline: A single track, one-day conferece about web design, accessibility, standards and more
+---
+
+State of the Browser is a one-day, single-track conference in the heart of London, with widely varying talks about the modern web, accessibility, standards and new browser features.


### PR DESCRIPTION
Added details for State of the Broswer 2019, a one-day conference about front-end, standards, accessibility, in London, UK.