### PR TITLE
updated date filter for showing conferences

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -50,6 +50,16 @@ module.exports = function(config) {
     }).toFormat('MMMM');
   });
 
+  config.addFilter('checkDate', (dateObj, month, year) => {
+    let current_month = DateTime.fromJSDate(dateObj, {
+        zone: 'utc'
+      }).toFormat('MMMM');
+      let current_year = DateTime.fromJSDate(dateObj, {
+        zone: 'utc'
+      }).year;
+      return current_month === month && current_year === year;
+  });
+
   config.addFilter('doesConfExist', (conferences, monthToTest, yearToTest) => {
     let length = conferences.filter(conf => {
       let month = DateTime.fromJSDate(conf.data.date, {

--- a/site/_includes/layouts/index.njk
+++ b/site/_includes/layouts/index.njk
@@ -68,8 +68,8 @@ layout: layouts/base.njk
         {{ month }} {{ year }}
       </h2>
       <ul class="conference-list">
-        {%- for conf in pagination.items -%} {% if conf.data.date |
-        getMonthName === month %}
+        {%- for conf in pagination.items -%} 
+        {% if conf.data.date | checkDate(month, year) %}
         <li class="conf">
           {% include "conference.njk" %}
         </li>


### PR DESCRIPTION
This is in reference to #169 

Currently only the month was check which was resulting in showing the current month i.e October 2019 conferences to show up in October 2020.
I updated the filter to check for both month and year.