### PR TITLE
jsconf Hawaii url fix

### DIFF
--- a/site/conferences/2020-jsconfhi-hawaii.md
+++ b/site/conferences/2020-jsconfhi-hawaii.md
@@ -1,6 +1,6 @@
 ---
 title: JSConf Hawaiʻi
-url: jsconfhi.com
+url: https://www.jsconfhi.com/
 cocUrl: https://www.jsconfhi.com/code-of-conduct/
 date: 2020-02-05
 endDate: 2020-02-07


### PR DESCRIPTION
fixed the link which was previously not working.
Sorry for the inconvenience.