### PR TITLE
Fix JS Kongress 2020 endDate

### DIFF
--- a/site/conferences/2020-JSKongress-Munich.md
+++ b/site/conferences/2020-JSKongress-Munich.md
@@ -3,7 +3,7 @@ title: JS Kongress 2020
 url: https://js-kongress.com/
 cocUrl: https://js-kongress.com/code-of-conduct/
 date: 2020-04-15
-endDate: 2019-04-16
+endDate: 2020-04-16
 location: Munich, Germany
 byline: The focus of JS Kongress 2020 is Scaling JS – Pushing the Limits. Massive Platforms, Data-Driven Architectures, and Modern APIs. The #DeepTrack is about all things JavaScript where YOU create the program!
 ---


### PR DESCRIPTION
The start date is `2020-04-15` so I guess the end date should be in 2020 as well.

<img width="501" alt="Screenshot 2020-02-04 at 18 27 32" src="https://user-images.githubusercontent.com/464300/73770128-2d50ac80-477c-11ea-820d-5ed553695362.png">
