### PR TITLE
Add HalfStack Online, updates for covid-19 postponements

### DIFF
--- a/site/conferences/2020-cityjs-london.md
+++ b/site/conferences/2020-cityjs-london.md
@@ -2,8 +2,8 @@
 title: CityJS Conference
 url: https://cityjsconf.org/home
 cocUrl: https://cityjsconf.org/coc
-date: 2020-03-27
-endDate: 2020-03-27
+date: 2020-09-14
+endDate: 2020-09-14
 location: London, England
 byline: CITY OF LONDON JAVASCRIPT CONFERENCE
 ---

--- a/site/conferences/2020-halfstack-charlotte.md
+++ b/site/conferences/2020-halfstack-charlotte.md
@@ -2,7 +2,7 @@
 title: HalfStack Charlotte
 url: https://halfstackconf.com/charlotte/
 cocUrl: https://halfstackconf.com/charlotte/code-of-conduct/
-date: 2020-04-24
+date: 2020-12-11
 location: Charlotte, North Carolina
 byline: Frontend, JavaScript, UI, Web, Development.
 ---

--- a/site/conferences/2020-halfstack-online.md
+++ b/site/conferences/2020-halfstack-online.md
@@ -1,0 +1,11 @@
+---
+title: HalfStack Online
+url: https://halfstackconf.com/online/
+cocUrl: https://halfstackconf.com/online/code-of-conduct/
+date: 2020-05-22
+location: Online
+byline: Frontend, JavaScript, UI, Web, Development.
+---
+
+An authentic, high value experience for attendees and sponsors focused on creative JavaScript and web development.
+

--- a/site/conferences/2020-halfstack-telaviv.md
+++ b/site/conferences/2020-halfstack-telaviv.md
@@ -2,7 +2,7 @@
 title: HalfStack Tel Aviv
 url: https://halfstackconf.com/telaviv/
 cocUrl: https://halfstackconf.com/telaviv/code-of-conduct/
-date: 2020-05-11
+date: 2020-10-19
 location: Tel Aviv-Yafo, Israel
 byline: Frontend, JavaScript, UI, Web, Development.
 ---

--- a/site/conferences/2020-react-finland.md
+++ b/site/conferences/2020-react-finland.md
@@ -4,7 +4,7 @@ url: https://react-finland.fi
 cocUrl: http://berlincodeofconduct.org
 date: 2020-05-12
 endDate: 2020-05-15
-location: Helsinki, Finland
+location: Online
 byline: Learn More about React, Explore Finland.
 ---
 


### PR DESCRIPTION
* Add HalfStack Online, 22nd of May
* New dates for HalfStack Charlotte, HalfStack Tel Aviv
* New dates for CityJS Conf
* React Finland is online only now, changed location

There are quite a few other events listed that are either canceled or postponed, but I wasn't sure if you want updates for those or not.