### PR TITLE
filter special chars from slugs for email flyout

### DIFF
--- a/site/_includes/conference.njk
+++ b/site/_includes/conference.njk
@@ -51,10 +51,10 @@
   {{ conf.data.byline }}
 </div>
 
-<div class="remindme card" id="reminder-{{ conf.fileSlug }}" aria-hidden="true">
+<div class="remindme card" id="reminder-{{ conf.fileSlug | slug }}" aria-hidden="true">
     
   <div class="card__face card__face--front">
-    <button aria-controls="reminder-{{ conf.fileSlug }}" aria-haspopup="true" aria-expanded="false">Email Conference Info</button>
+    <button aria-controls="reminder-{{ conf.fileSlug | slug }}" aria-haspopup="true" aria-expanded="false">Email Conference Info</button>
   </div>
   
   <div class="flyout card__face card__face--back">
@@ -75,7 +75,7 @@
         </svg>
       </button>
     </form>
-    <button aria-controls="reminder-{{ conf.fileSlug }}" aria-haspopup="true" aria-expanded="false">Close</button>
+    <button aria-controls="reminder-{{ conf.fileSlug | slug }}" aria-haspopup="true" aria-expanded="false">Close</button>
   </div>
 </div>
 


### PR DESCRIPTION
slug is used as id in dom, leading to css selector syntax errors. use slug filter here to avoid.

ex:  Uncaught DOMException: Failed to execute 'querySelector' on 'Document': '#reminder-2021-javaScript-&-friends-conference' is not a valid selector.

![Screenshot 2021-08-18 010138](https://user-images.githubusercontent.com/1982042/129861360-136495fa-10ce-4499-9adf-94e7acc5c821.png)

![Screenshot 2021-08-18 010153](https://user-images.githubusercontent.com/1982042/129861358-094620fd-f729-45bf-95c1-3d88edc47c39.png)

![Screenshot 2021-08-18 010205](https://user-images.githubusercontent.com/1982042/129861357-922a37bd-d49f-4691-a815-eb2d74aa6bbb.png)
